### PR TITLE
remove override keyword. code now compiles.

### DIFF
--- a/contracts/CaptureTheFlag.sol
+++ b/contracts/CaptureTheFlag.sol
@@ -15,7 +15,7 @@ contract CaptureTheFlag is ERC2771Recipient {
         _setTrustedForwarder(forwarder);
     }
 
-    string public override versionRecipient = "3.0.0";
+    string public versionRecipient = "3.0.0";
 
     function captureTheFlag() external {
         address previousHolder = currentHolder;


### PR DESCRIPTION
When compiling, the below error was produced

`CompileError: TypeError: Public state variable has override specified but does not override anything.`

I removed the `override` specifier and then compiled the code and did test the overall execution. It now runs fine as expected.